### PR TITLE
chore: setup AWS permissions for goreleaser

### DIFF
--- a/.github/workflows/release-from-tag.yaml
+++ b/.github/workflows/release-from-tag.yaml
@@ -49,6 +49,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PORTERSUPPORT_GITHUB_TOKEN }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@main
+        with:
+          role-to-assume: porter-releases
+          aws-region: us-east-2
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release-from-tag.yaml
+++ b/.github/workflows/release-from-tag.yaml
@@ -65,3 +65,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PORTERSUPPORT_GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.tagVersion }}
+          RELEASE_BUCKET: ${{ vars.RELEASE_BUCKET }}


### PR DESCRIPTION
## Description
Adds a step using the aws credentials action set to the `porter-releases` role, which already exists in the prod account and is attached to the github OIDC provider.

<img width="1233" height="1170" alt="image" src="https://github.com/user-attachments/assets/4d95a633-bb25-4bdc-92fa-626f8ec15b03" />

