### PR TITLE
use GitHub app token for GHCR push

### DIFF
--- a/.github/workflows/release-from-tag.yaml
+++ b/.github/workflows/release-from-tag.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Docker logins
         run: echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
Latest porter-agent release failed during docker authentication: https://github.com/porter-dev/ci/actions/runs/25997316486

This PR switches the GHCR `docker login` step to use the Porter Internal CI app token (minted earlier in the `app-token` step) instead of the workflow's autogenerated `secrets.GITHUB_TOKEN`. The former creds convey "push packages" permissions on the porter-dev/releases repo.