### PR TITLE
feat: publish latest.txt to R2 after goreleaser

### DIFF
--- a/.github/workflows/release-from-tag.yaml
+++ b/.github/workflows/release-from-tag.yaml
@@ -75,3 +75,16 @@ jobs:
           RELEASE_BUCKET_ENDPOINT: ${{ vars.RELEASE_BUCKET_ENDPOINT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+
+      - name: Publish latest pointer
+        run: |
+          echo -n "${{ github.event.inputs.tagVersion }}" > latest.txt
+          aws s3 cp latest.txt "s3://${RELEASE_BUCKET}/releases/latest.txt" \
+            --endpoint-url "${RELEASE_BUCKET_ENDPOINT}" \
+            --content-type "text/plain"
+        env:
+          RELEASE_BUCKET: ${{ vars.RELEASE_BUCKET }}
+          RELEASE_BUCKET_ENDPOINT: ${{ vars.RELEASE_BUCKET_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.RELEASE_BUCKET_REGION }}

--- a/.github/workflows/release-from-tag.yaml
+++ b/.github/workflows/release-from-tag.yaml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Publish latest pointer
         run: |
-          echo -n "${{ github.event.inputs.tagVersion }}" > latest.txt
-          aws s3 cp latest.txt "s3://${RELEASE_BUCKET}/releases/latest.txt" \
+          echo -n "${{ github.event.inputs.tagVersion }}" > latest
+          aws s3 cp latest "s3://${RELEASE_BUCKET}/releases/latest" \
             --endpoint-url "${RELEASE_BUCKET_ENDPOINT}" \
             --content-type "text/plain"
         env:


### PR DESCRIPTION
## Summary
Add a step to the release action so that we create a metadata `latest.txt` file in the R2 bucket. This will serve as a pointer to the install script so it knows which version of the binaries to pull, and so it can stop relying on Github.