### PR TITLE
fix go.mod path in cli release workflow

### DIFF
--- a/.github/workflows/release-from-tag.yaml
+++ b/.github/workflows/release-from-tag.yaml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       workDir:
-        description: "Directory where the go.mod file is located"
+        description: "Directory where the .goreleaser.yaml file is located"
         required: true
         type: string
       checkoutTag:
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ github.event.inputs.workDir }}/go.mod
+          go-version-file: go.mod
           cache: false
 
       - name: Docker logins


### PR DESCRIPTION
Follow-up from https://github.com/porter-dev/code/pull/5316 which collapsed all monorepo directories into a single Go module; `go.mod` now lives in the repo root.

Fix for this failed workflow run: https://github.com/porter-dev/ci/actions/runs/27354442821/job/80824799855